### PR TITLE
docs: remove redundant uv pip install -e . step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ uv sync --dev
 source .venv/bin/activate
 ```
 
-For development, make sure to install the project with the `-e` flag
-so the source code isn't distributed to `.venv`:
-```
-uv pip install -e .
-```
-
 Then you can run the default cli, which can be customized in `cli.py` and `pyproject.toml`  
 ```
 $ python-template


### PR DESCRIPTION
## Summary

- Removes the `uv pip install -e .` instruction from the README

`uv sync --dev` already installs the project in editable mode — the extra step was redundant and could confuse users into thinking it's required.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)