### PR TITLE
fix: replace placeholder description in pyproject.toml during template init

### DIFF
--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -43,11 +43,18 @@ jobs:
         run: |
           repo_slug="${{ steps.names.outputs.repo_slug }}"
           repo_snake="${{ steps.names.outputs.repo_snake }}"
+          repo_desc="${{ github.event.repository.description }}"
 
           # replace dash-style placeholder
           grep -lr --exclude-dir=.git 'python-template' . | xargs -r sed -i "s/python-template/${repo_slug}/g"
           # replace snake_case placeholder
           grep -lr --exclude-dir=.git 'python_template' . | xargs -r sed -i "s/python_template/${repo_snake}/g"
+          # replace pyproject.toml description placeholder
+          if [ -n "$repo_desc" ]; then
+            sed -i "s/Add your description here/${repo_desc}/" pyproject.toml
+          else
+            sed -i '/^description = "Add your description here"/d' pyproject.toml
+          fi
 
       - name: Rename files and directories
         run: |


### PR DESCRIPTION
## Summary

- `template-init.yml` now replaces `"Add your description here"` in `pyproject.toml` with the repo's GitHub description (via `github.event.repository.description`)
- If no description is set, the placeholder line is removed instead

## Behaviour

| Scenario | Result |
|----------|--------|
| Repo has a description | `description = "My cool project"` |
| Repo has no description | `description` key removed from `pyproject.toml` |

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)