### PR TITLE
fix(workflow): repair always-skipped 'Replace repo owner' if-syntax

### DIFF
--- a/.github/workflows/template-init.yml
+++ b/.github/workflows/template-init.yml
@@ -33,7 +33,13 @@ jobs:
         run: git switch -c template-init
 
       - name: Replace repo owner
-        if: ${{ github.event.repository.owner.login }} != marksverdhei
+        # The previous form `${{ ... }} != marksverdhei` pre-substituted only the
+        # left side, leaving GHA to evaluate `<owner_login> != marksverdhei` as
+        # an expression — both unquoted identifiers resolved to null context
+        # refs, so `null != null` was always false and this step was *always
+        # skipped*. New repos kept marksverdhei references unreplaced. The
+        # comparison has to live entirely inside one expression scope.
+        if: github.event.repository.owner.login != 'marksverdhei'
         run: |
           repo_owner="${{ steps.names.outputs.repo_owner }}"
           # replace repo owner placeholder


### PR DESCRIPTION
## Bug

\`\`\`yaml
- name: Replace repo owner
  if: \${{ github.event.repository.owner.login }} != marksverdhei
\`\`\`

This mixes \`\${{ }}\` pre-substitution with a bare-text right-hand side. GHA evaluates the entire \`if\` value as an expression after substitution:

1. \`\${{ github.event.repository.owner.login }}\` is substituted → e.g. \`someuser\`
2. The literal becomes: \`someuser != marksverdhei\`
3. GHA parses that as an expression. Both \`someuser\` and \`marksverdhei\` are unquoted identifiers → resolved as undefined context refs (both \`null\`)
4. \`null != null\` is \`false\`
5. **Step always skipped**

Effect: every new repo created from this template kept its \`marksverdhei\` references unreplaced. The bug never bit Markus's own usage of the template (other workflows would have caught it cosmetically) but is wrong for anyone else cloning the template — and silently so.

## Fix

\`\`\`yaml
- name: Replace repo owner
  if: github.event.repository.owner.login != 'marksverdhei'
\`\`\`

Move the comparison entirely inside one expression scope. The quoted literal and the property reference now share the same evaluator, and the step runs whenever the owner isn't \`marksverdhei\` (matching the intent in the inline comment).

## Why no test

This is a CI workflow — no local-runnable test suite to add to. The next time a non-marksverdhei user (real or test) clones from this template, the step will run and \`marksverdhei\` references will be replaced as documented.